### PR TITLE
Annihilate pyclaw.io.

### DIFF
--- a/src/forestclaw/fileio/__init__.py
+++ b/src/forestclaw/fileio/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import absolute_import
 import logging
-logger = logging.getLogger('pyclaw.io')
+logger = logging.getLogger('pyclaw.fileio')
 
 from . import ascii
 __all__ = ["ascii.read", "ascii.write"]

--- a/src/forestclaw/fileio/ascii.py
+++ b/src/forestclaw/fileio/ascii.py
@@ -15,7 +15,7 @@ from clawpack.pyclaw.fileio.ascii import write
 from clawpack.pyclaw.fileio.ascii import read
 from clawpack.pyclaw.util import read_data_line
 
-logger = logging.getLogger('pyclaw.io')
+logger = logging.getLogger('pyclaw.fileio')
 
 
 def write_patch_header(f, patch):

--- a/src/petclaw/fileio/hdf5.py
+++ b/src/petclaw/fileio/hdf5.py
@@ -19,7 +19,7 @@ from clawpack.petclaw import geometry
 from clawpack import petclaw
 import six
 
-logger = logging.getLogger('pyclaw.io')
+logger = logging.getLogger('pyclaw.fileio')
 
 try:
     import h5py

--- a/src/pyclaw/controller.py
+++ b/src/pyclaw/controller.py
@@ -456,12 +456,12 @@ class OutputController(object):
     @file_format.setter
     def file_format(self, value):
         if value.lower() == 'petsc':
-            self._io_module = __import__("clawpack.petclaw.io.petsc", 
-                                         fromlist=["clawpack.petclaw.io"])
+            self._io_module = __import__("clawpack.petclaw.fileio.petsc", 
+                                         fromlist=["clawpack.petclaw.fileio"])
             self._file_format = value
         else:
-            self._io_module = __import__("clawpack.pyclaw.io.%s" % value, 
-                                         fromlist=['clawpack.pyclaw.io'])
+            self._io_module = __import__("clawpack.pyclaw.fileio.%s" % value, 
+                                         fromlist=['clawpack.pyclaw.fileio'])
             self._file_format = value
 
         

--- a/src/pyclaw/fileio/__init__.py
+++ b/src/pyclaw/fileio/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import absolute_import
 import logging
-logger = logging.getLogger('pyclaw.io')
+logger = logging.getLogger('pyclaw.fileio')
 
 from . import ascii
 __all__ = ['ascii.read', 'ascii.write']

--- a/src/pyclaw/fileio/ascii.py
+++ b/src/pyclaw/fileio/ascii.py
@@ -14,7 +14,7 @@ import clawpack.pyclaw as pyclaw
 from clawpack.pyclaw.util import read_data_line
 from six.moves import range
 
-logger = logging.getLogger('pyclaw.io')
+logger = logging.getLogger('pyclaw.fileio')
 
 def write(solution, frame, path, file_prefix='fort', write_aux=False,
                     options={}, write_p=False):

--- a/src/pyclaw/fileio/binary.py
+++ b/src/pyclaw/fileio/binary.py
@@ -16,7 +16,7 @@ import numpy as np
 import clawpack.pyclaw as pyclaw
 from six.moves import range
 
-logger = logging.getLogger('pyclaw.io')
+logger = logging.getLogger('pyclaw.fileio')
 
 
 def read(solution,frame,path='./',file_prefix='fort',read_aux=False,

--- a/src/pyclaw/fileio/hdf5.py
+++ b/src/pyclaw/fileio/hdf5.py
@@ -22,7 +22,7 @@ import logging
 from clawpack import pyclaw
 import six
 
-logger = logging.getLogger('pyclaw.io')
+logger = logging.getLogger('pyclaw.fileio')
 
 # Import appropriate hdf5 package
 use_h5py = False

--- a/src/pyclaw/fileio/netcdf.py
+++ b/src/pyclaw/fileio/netcdf.py
@@ -37,7 +37,7 @@ import clawpack.pyclaw.solution
 import six
 from six.moves import range
 
-logger = logging.getLogger('pyclaw.io')
+logger = logging.getLogger('pyclaw.fileio')
 
 # Import appropriate netcdf package
 use_netcdf4 = False

--- a/src/pyclaw/fileio/setup.py
+++ b/src/pyclaw/fileio/setup.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
-    config = Configuration('io', parent_package, top_path)
+    config = Configuration('fileio', parent_package, top_path)
     return config
 
 if __name__ == '__main__':

--- a/src/pyclaw/log.config
+++ b/src/pyclaw/log.config
@@ -42,7 +42,7 @@ parent=(pyclaw)
 [logger_io]
 level=NOTSET
 propagate=0
-qualname=pyclaw.io
+qualname=pyclaw.fileio
 handlers=file
 channel=io
 parent=(pyclaw)

--- a/src/pyclaw/solution.py
+++ b/src/pyclaw/solution.py
@@ -298,7 +298,7 @@ class Solution(object):
                                 write_aux=write_aux,options=options,
                            write_p=write_p)
             msg = "Wrote out solution in format %s for time t=%s" % (form,self.t)
-            logging.getLogger('pyclaw.io').info(msg)
+            logging.getLogger('pyclaw.fileio').info(msg)
 
         
     def read(self, frame, path='./_output', file_format='ascii', 


### PR DESCRIPTION
I think the only important change here is the one in pyclaw/src/pyclaw/fileio/setup.py.  It was mistakenly registering the subpackage still as pyclaw.io.